### PR TITLE
minor changes to make environment gym-compatible

### DIFF
--- a/gym_panda/envs/panda_env.py
+++ b/gym_panda/envs/panda_env.py
@@ -61,9 +61,9 @@ class PandaEnv(gym.Env):
             reward = 0
             done = True
 
-        info = state_object
+        info = {'object_position': state_object}
         self.observation = state_robot + state_fingers
-        return self.observation, reward, done, info
+        return np.array(self.observation).astype(np.float32), reward, done, info
 
     def reset(self):
         self.step_counter = 0
@@ -90,7 +90,7 @@ class PandaEnv(gym.Env):
         state_fingers = (p.getJointState(self.pandaUid,9)[0], p.getJointState(self.pandaUid, 10)[0])
         self.observation = state_robot + state_fingers
         p.configureDebugVisualizer(p.COV_ENABLE_RENDERING,1)
-        return self.observation
+        return np.array(self.observation).astype(np.float32)
 
     def render(self, mode='human'):
         view_matrix = p.computeViewMatrixFromYawPitchRoll(cameraTargetPosition=[0.7,0,0.05],


### PR DESCRIPTION
```
from stable_baselines.common.env_checker import check_env

env = PandaEnv()
# If the environment don't follow the interface, an error will be thrown
check_env(env, warn=True)
```

Used this to determine if the environment is gym-compatible and it throws a few errors. So I'm proposing changes to fix them.